### PR TITLE
[FIX] Compute folio_id from reservation_id

### DIFF
--- a/pms/models/pms_service.py
+++ b/pms/models/pms_service.py
@@ -282,7 +282,7 @@ class PmsService(models.Model):
             qty = sum(service.service_line_ids.mapped("day_qty"))
             service.product_qty = qty
 
-    @api.depends("reservation_id")
+    @api.depends("reservation_id", "reservation_id.folio_id")
     def _compute_folio_id(self):
         for record in self:
             if record.reservation_id:

--- a/pms/views/pms_reservation_views.xml
+++ b/pms/views/pms_reservation_views.xml
@@ -467,8 +467,16 @@
                                         decoration-success="is_board_service == True"
                                     >
                                         <field name="is_board_service" invisible="1" />
-                                        <field name="company_id" invisible="0" />
-                                        <field name="pms_property_id" invisible="0" />
+                                        <field
+                                            name="company_id"
+                                            invisible="1"
+                                            readonly="1"
+                                        />
+                                        <field
+                                            name="pms_property_id"
+                                            invisible="1"
+                                            readonly="1"
+                                        />
                                         <button
                                             type="object"
                                             class="oe_stat_button"
@@ -481,7 +489,11 @@
                                             invisible="1"
                                             readonly="1"
                                         />
-                                        <field name="folio_id" invisible="1" />
+                                        <field
+                                            name="folio_id"
+                                            invisible="1"
+                                            readonly="1"
+                                        />
                                         <field
                                             name="reservation_id"
                                             invisible="1"


### PR DESCRIPTION
The computed folio_id in the services does not jump properly because the folio is created in the create method of the reservation, the folio_id field of the service must be readonly so that the empty value does not arrive and the compute of the folio skips